### PR TITLE
Compatibility: support macOS

### DIFF
--- a/src/umqtt.c
+++ b/src/umqtt.c
@@ -801,7 +801,7 @@ int umqtt_init(struct umqtt_client *cl, struct ev_loop *loop, const char *host, 
 
     memset(cl, 0, sizeof(struct umqtt_client));
 
-    sock = tcp_connect(host, port, SOCK_NONBLOCK | SOCK_CLOEXEC, NULL, &eai);
+    sock = tcp_connect(host, port, O_NONBLOCK | O_CLOEXEC, NULL, &eai);
     if (sock < 0) {
         umqtt_log_err("tcp_connect failed: %s\n", strerror(errno));
         return -1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,6 +30,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <fcntl.h>
 
 #include "log.h"
 #include "utils.h"
@@ -81,7 +82,9 @@ int tcp_connect(const char *host, int port, int flags, bool *inprogress, int *ea
     if (!addr)
         goto free_addrinfo;
 
-    sock = socket(AF_INET, SOCK_STREAM | flags, 0);
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    int old_flags = fcntl(sock, F_GETFL);
+    fcntl(sock, F_SETFL, old_flags | flags);
     if (sock < 0)
         goto free_addrinfo;
 


### PR DESCRIPTION
In macOS  10.14.5 (18F132), there are no `SOCK_NONBLOCK` and `SOCK_CLOEXEC` flags to set socket, therefor replaced them with `O_NONBLOCK` and `O_CLOEXEC` and use `fcntl` to set them.