### PR TITLE
Fix: variable header remain length in big-endian order

### DIFF
--- a/src/umqtt.c
+++ b/src/umqtt.c
@@ -67,7 +67,7 @@ static void umqtt_free(struct umqtt_client *cl)
     buffer_free(&cl->wb);
 
 #if UMQTT_SSL_SUPPORT
-     umqtt_ssl_free(cl->ssl);
+    umqtt_ssl_free(cl->ssl);
 #endif
 
     if (cl->sock > 0)

--- a/src/umqtt.h
+++ b/src/umqtt.h
@@ -42,6 +42,7 @@
 #define UMQTT_MAX_CONNECT_TIME      5  /* second */
 
 #define UMQTT_MAX_REMLEN            268435455
+#define UMQTT_MAX_REMLEN_BYTES      4
 
 /* MQTT Control Packet type */
 enum {


### PR DESCRIPTION
The connection was broken when i try to receive a message which remain data is larger than 127 bytes, i found the remain length parsed by `parse_remaining_length` is in little-endian order.
The [MQTT RFC 1.5.2](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718015) specific that `Integer data values are 16 bits in big-endian order`, this pr is in order to fix this issue.