### PR TITLE
Support for binary will and important bug in handling PUBLISH messages

### DIFF
--- a/src/umqtt.c
+++ b/src/umqtt.c
@@ -246,8 +246,8 @@ static void handle_unsuback(struct umqtt_client *cl)
 static void handle_publish(struct umqtt_client *cl)
 {
     struct umqtt_packet *pkt = &cl->pkt;
-    uint8_t qos = (pkt->flags > 1) & 0x03;
-    bool dup = (pkt->flags > 3) & 0x1;
+    uint8_t qos = (pkt->flags >> 1) & 0x03;
+    bool dup = (pkt->flags >> 3) & 0x1;
     struct buffer *rb = &cl->rb;
     uint16_t mid = 0;
     int payloadlen;

--- a/src/umqtt.c
+++ b/src/umqtt.c
@@ -345,7 +345,7 @@ static int umqtt_connect(struct umqtt_client *cl, struct umqtt_connect_opts *opt
         will = true;
 
         remlen += strlen(opts->will_topic) + 2;
-        remlen += strlen(opts->will_message) + 2;
+        remlen += (opts->will_message_len ? : strlen(opts->will_message)) + 2;
 
         flags |= 1 << 2;
         flags |= (opts->will_qos & 0x3) << 3;
@@ -378,8 +378,10 @@ static int umqtt_connect(struct umqtt_client *cl, struct umqtt_connect_opts *opt
     umqtt_put_string(wb, client_id);
 
     if (will) {
+        size_t will_message_len = opts->will_message_len ? : strlen(opts->will_message);
         umqtt_put_string(wb, opts->will_topic);
-        umqtt_put_string(wb, opts->will_message);
+        buffer_put_u16(wb, htons(will_message_len));
+        buffer_put_data(wb, opts->will_message, will_message_len);
     }
 
     if (opts->username) {

--- a/src/umqtt.h
+++ b/src/umqtt.h
@@ -134,7 +134,8 @@ struct umqtt_connect_opts {
     const char *password;
 
     const char *will_topic;
-    const char *will_message;
+    const void *will_message;
+    size_t will_message_len;
     uint8_t will_qos;
     bool will_retain;
 };


### PR DESCRIPTION
This adds support for sending binary (arbitrary) wills (e.g. for Sparkplug death certificates) and fixes a very important bug which broke responses to PUBLISH messages with QOS2. Have a look into the commit messages for more details.

The binary will implementation in 095b2bd8b6cd6944c331b962e133fa8c9b921660 may not actually be ideal. Perhaps it's better to break the API and rename `will_message` (see commit message for a discussion). What do you think?